### PR TITLE
Filter out deleted organizers by default

### DIFF
--- a/src/Offer/RequestParser/WorkflowStatusOfferRequestParser.php
+++ b/src/Offer/RequestParser/WorkflowStatusOfferRequestParser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Offer\RequestParser;
+
+use CultuurNet\UDB3\Search\Http\Parameters\SymfonyParameterBagAdapter;
+use CultuurNet\UDB3\Search\Offer\OfferQueryBuilderInterface;
+use CultuurNet\UDB3\Search\Offer\WorkflowStatus;
+use Symfony\Component\HttpFoundation\Request;
+
+final class WorkflowStatusOfferRequestParser implements OfferRequestParserInterface
+{
+    private const PARAMETER = 'workflowStatus';
+    private const DEFAULT = 'APPROVED,READY_FOR_VALIDATION';
+
+    public function parse(Request $request, OfferQueryBuilderInterface $offerQueryBuilder)
+    {
+        $parameterBagReader = new SymfonyParameterBagAdapter($request->query);
+
+        $workflowStatuses = $parameterBagReader->getExplodedStringFromParameter(
+            self::PARAMETER,
+            self::DEFAULT,
+            function ($workflowStatus) {
+                return new WorkflowStatus($workflowStatus);
+            }
+        );
+
+        return $offerQueryBuilder->withWorkflowStatusFilter(...$workflowStatuses);
+    }
+}

--- a/src/OfferSearchController.php
+++ b/src/OfferSearchController.php
@@ -214,11 +214,6 @@ class OfferSearchController
             );
         }
 
-        $workflowStatuses = $this->getWorkflowStatusesFromQuery($parameterBag);
-        if (!empty($workflowStatuses)) {
-            $queryBuilder = $queryBuilder->withWorkflowStatusFilter(...$workflowStatuses);
-        }
-
         $availableFrom = $this->getAvailabilityFromQuery($request, 'availableFrom');
         $availableTo = $this->getAvailabilityFromQuery($request, 'availableTo');
         if ($availableFrom || $availableTo) {
@@ -470,21 +465,6 @@ class OfferSearchController
             $queryParameter,
             function ($value) {
                 return new RegionId($value);
-            }
-        );
-    }
-
-    /**
-     * @param ParameterBagInterface $parameterBag
-     * @return WorkflowStatus[]
-     */
-    private function getWorkflowStatusesFromQuery(ParameterBagInterface $parameterBag)
-    {
-        return $parameterBag->getExplodedStringFromParameter(
-            'workflowStatus',
-            'APPROVED,READY_FOR_VALIDATION',
-            function ($workflowStatus) {
-                return new WorkflowStatus($workflowStatus);
             }
         );
     }

--- a/src/Organizer/RequestParser/CompositeOrganizerRequestParser.php
+++ b/src/Organizer/RequestParser/CompositeOrganizerRequestParser.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace CultuurNet\UDB3\Search\Http\Organizer\RequestParser;
+
+use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class CompositeOrganizerRequestParser implements OrganizerRequestParser
+{
+    /**
+     * @var OrganizerRequestParser[]
+     */
+    private $parsers = [];
+
+    public function __construct()
+    {
+        $this->parsers = [];
+    }
+
+    public function withParser(OrganizerRequestParser $parser)
+    {
+        $c = clone $this;
+        $c->parsers[] = $parser;
+        return $c;
+    }
+
+    public function parse(
+        Request $request,
+        OrganizerQueryBuilderInterface $organizerQueryBuilder
+    ): OrganizerQueryBuilderInterface {
+        foreach ($this->parsers as $parser) {
+            $organizerQueryBuilder = $parser->parse($request, $organizerQueryBuilder);
+        }
+        return $organizerQueryBuilder;
+    }
+}

--- a/src/Organizer/RequestParser/OrganizerRequestParser.php
+++ b/src/Organizer/RequestParser/OrganizerRequestParser.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace CultuurNet\UDB3\Search\Http\Organizer\RequestParser;
+
+use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+interface OrganizerRequestParser
+{
+    public function parse(
+        Request $request,
+        OrganizerQueryBuilderInterface $organizerQueryBuilder
+    ): OrganizerQueryBuilderInterface;
+}

--- a/src/Organizer/RequestParser/WorkflowStatusOrganizerRequestParser.php
+++ b/src/Organizer/RequestParser/WorkflowStatusOrganizerRequestParser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Search\Http\Organizer\RequestParser;
+
+use CultuurNet\UDB3\Search\Http\Parameters\SymfonyParameterBagAdapter;
+use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
+use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
+use Symfony\Component\HttpFoundation\Request;
+
+final class WorkflowStatusOrganizerRequestParser implements OrganizerRequestParser
+{
+    private const PARAMETER = 'workflowStatus';
+    private const DEFAULT = 'ACTIVE';
+
+    public function parse(Request $request, OrganizerQueryBuilderInterface $organizerQueryBuilder): OrganizerQueryBuilderInterface
+    {
+        $parameterBagReader = new SymfonyParameterBagAdapter($request->query);
+
+        $workflowStatuses = $parameterBagReader->getExplodedStringFromParameter(
+            self::PARAMETER,
+            self::DEFAULT,
+            function ($workflowStatus) {
+                return new WorkflowStatus($workflowStatus);
+            }
+        );
+
+        return $organizerQueryBuilder->withWorkflowStatusFilter(...$workflowStatuses);
+    }
+}

--- a/src/Organizer/RequestParser/WorkflowStatusOrganizerRequestParser.php
+++ b/src/Organizer/RequestParser/WorkflowStatusOrganizerRequestParser.php
@@ -14,8 +14,10 @@ final class WorkflowStatusOrganizerRequestParser implements OrganizerRequestPars
     private const PARAMETER = 'workflowStatus';
     private const DEFAULT = 'ACTIVE';
 
-    public function parse(Request $request, OrganizerQueryBuilderInterface $organizerQueryBuilder): OrganizerQueryBuilderInterface
-    {
+    public function parse(
+        Request $request,
+        OrganizerQueryBuilderInterface $organizerQueryBuilder
+    ): OrganizerQueryBuilderInterface {
         $parameterBagReader = new SymfonyParameterBagAdapter($request->query);
 
         $workflowStatuses = $parameterBagReader->getExplodedStringFromParameter(

--- a/src/OrganizerSearchController.php
+++ b/src/OrganizerSearchController.php
@@ -6,6 +6,7 @@ use CultuurNet\UDB3\Address\PostalCode;
 use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\Search\Creator;
+use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\OrganizerRequestParser;
 use CultuurNet\UDB3\Search\Http\Parameters\OrganizerParameterWhiteList;
 use CultuurNet\UDB3\Search\Http\Parameters\ParameterBagInterface;
 use CultuurNet\UDB3\Search\Http\Parameters\SymfonyParameterBagAdapter;
@@ -49,16 +50,23 @@ class OrganizerSearchController
     private $queryStringFactory;
 
     /**
+     * @var OrganizerRequestParser
+     */
+    private $organizerRequestParser;
+
+    /**
      * @param OrganizerQueryBuilderInterface $queryBuilder
      * @param OrganizerSearchServiceInterface $searchService
-     * @param PagedCollectionFactoryInterface|null $pagedCollectionFactory
+     * @param OrganizerRequestParser $organizerRequestParser
      * @param QueryStringFactoryInterface $queryStringFactory
+     * @param PagedCollectionFactoryInterface|null $pagedCollectionFactory
      */
     public function __construct(
         OrganizerQueryBuilderInterface $queryBuilder,
         OrganizerSearchServiceInterface $searchService,
-        PagedCollectionFactoryInterface $pagedCollectionFactory = null,
-        QueryStringFactoryInterface $queryStringFactory
+        OrganizerRequestParser $organizerRequestParser,
+        QueryStringFactoryInterface $queryStringFactory,
+        PagedCollectionFactoryInterface $pagedCollectionFactory = null
     ) {
         if (is_null($pagedCollectionFactory)) {
             $pagedCollectionFactory = new ResultTransformingPagedCollectionFactory(
@@ -71,6 +79,7 @@ class OrganizerSearchController
         $this->pagedCollectionFactory = $pagedCollectionFactory;
         $this->organizerParameterWhiteList = new OrganizerParameterWhiteList();
         $this->queryStringFactory = $queryStringFactory;
+        $this->organizerRequestParser = $organizerRequestParser;
     }
 
     /**
@@ -95,6 +104,8 @@ class OrganizerSearchController
         $queryBuilder = $this->queryBuilder
             ->withStart(new Natural($start))
             ->withLimit(new Natural($limit));
+
+        $queryBuilder = $this->organizerRequestParser->parse($request, $queryBuilder);
 
         $textLanguages = $this->getLanguagesFromQuery($parameterBag, 'textLanguages');
 

--- a/src/Parameters/OrganizerParameterWhiteList.php
+++ b/src/Parameters/OrganizerParameterWhiteList.php
@@ -19,6 +19,7 @@ class OrganizerParameterWhiteList extends AbstractParameterWhiteList
             'creator',
             'labels',
             'textLanguages',
+            'workflowStatus',
         ];
     }
 }

--- a/src/Parameters/OrganizerParameterWhiteList.php
+++ b/src/Parameters/OrganizerParameterWhiteList.php
@@ -20,6 +20,7 @@ class OrganizerParameterWhiteList extends AbstractParameterWhiteList
             'labels',
             'textLanguages',
             'workflowStatus',
+            'disableDefaultFilters',
         ];
     }
 }

--- a/tests/MockOfferQueryBuilder.php
+++ b/tests/MockOfferQueryBuilder.php
@@ -150,8 +150,11 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
         return $c;
     }
 
-    public function withRegionFilter(StringLiteral $regionIndexName, StringLiteral $regionDocumentType, RegionId $regionId)
-    {
+    public function withRegionFilter(
+        StringLiteral $regionIndexName,
+        StringLiteral $regionDocumentType,
+        RegionId $regionId
+    ) {
         $c = clone $this;
         $c->mockQuery['region']['index'] = (string) $regionIndexName;
         $c->mockQuery['region']['type'] = (string) $regionDocumentType;

--- a/tests/MockOfferQueryBuilder.php
+++ b/tests/MockOfferQueryBuilder.php
@@ -89,6 +89,10 @@ final class MockOfferQueryBuilder implements OfferQueryBuilderInterface
 
     public function withWorkflowStatusFilter(WorkflowStatus ...$workflowStatuses)
     {
+        if (empty($workflowStatuses)) {
+            return $this;
+        }
+
         $c = clone $this;
         $c->mockQuery['workflowStatus'] = array_map(function (WorkflowStatus $workflowStatus) {
             return (string) $workflowStatus;

--- a/tests/OfferSearchControllerTest.php
+++ b/tests/OfferSearchControllerTest.php
@@ -24,6 +24,7 @@ use CultuurNet\UDB3\Search\Http\Offer\RequestParser\CompositeOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DistanceOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\DocumentLanguageOfferRequestParser;
 use CultuurNet\UDB3\Search\Http\Offer\RequestParser\SortByOfferRequestParser;
+use CultuurNet\UDB3\Search\Http\Offer\RequestParser\WorkflowStatusOfferRequestParser;
 use CultuurNet\UDB3\Search\Offer\AudienceType;
 use CultuurNet\UDB3\Search\Offer\CalendarType;
 use CultuurNet\UDB3\Search\Offer\Cdbid;
@@ -106,7 +107,8 @@ class OfferSearchControllerTest extends \PHPUnit_Framework_TestCase
             ->withParser(new AgeRangeOfferRequestParser())
             ->withParser(new DistanceOfferRequestParser(new MockDistanceFactory()))
             ->withParser(new DocumentLanguageOfferRequestParser())
-            ->withParser(new SortByOfferRequestParser());
+            ->withParser(new SortByOfferRequestParser())
+            ->withParser(new WorkflowStatusOfferRequestParser());
 
         $this->searchService = $this->createMock(OfferSearchServiceInterface::class);
 

--- a/tests/OrganizerSearchControllerTest.php
+++ b/tests/OrganizerSearchControllerTest.php
@@ -7,6 +7,8 @@ use CultuurNet\UDB3\Label\ValueObjects\LabelName;
 use CultuurNet\UDB3\Language;
 use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Search\Creator;
+use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\CompositeOrganizerRequestParser;
+use CultuurNet\UDB3\Search\Http\Organizer\RequestParser\WorkflowStatusOrganizerRequestParser;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
 use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
@@ -49,7 +51,8 @@ class OrganizerSearchControllerTest extends \PHPUnit_Framework_TestCase
         $this->controller = new OrganizerSearchController(
             $this->queryBuilder,
             $this->searchService,
-            null,
+            (new CompositeOrganizerRequestParser())
+                ->withParser(new WorkflowStatusOrganizerRequestParser()),
             $this->queryStringFactory
         );
     }

--- a/tests/OrganizerSearchControllerTest.php
+++ b/tests/OrganizerSearchControllerTest.php
@@ -9,6 +9,7 @@ use CultuurNet\UDB3\ReadModel\JsonDocument;
 use CultuurNet\UDB3\Search\Creator;
 use CultuurNet\UDB3\Search\Organizer\OrganizerQueryBuilderInterface;
 use CultuurNet\UDB3\Search\Organizer\OrganizerSearchServiceInterface;
+use CultuurNet\UDB3\Search\Organizer\WorkflowStatus;
 use CultuurNet\UDB3\Search\PagedResultSet;
 use Symfony\Component\HttpFoundation\Request;
 use ValueObjects\Geography\Country;
@@ -73,6 +74,7 @@ class OrganizerSearchControllerTest extends \PHPUnit_Framework_TestCase
                     'Uitpas',
                     'foo',
                 ],
+                'workflowStatus' => 'ACTIVE,DELETED',
                 'domain' => 'www.publiq.be'
             ]
         );
@@ -91,6 +93,7 @@ class OrganizerSearchControllerTest extends \PHPUnit_Framework_TestCase
             ->withCreatorFilter(new Creator('Jan Janssens'))
             ->withLabelFilter(new LabelName('Uitpas'))
             ->withLabelFilter(new LabelName('foo'))
+            ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'), new WorkflowStatus('DELETED'))
             ->withStart(new Natural(30))
             ->withLimit(new Natural(10));
 
@@ -139,6 +142,25 @@ class OrganizerSearchControllerTest extends \PHPUnit_Framework_TestCase
         $expectedQueryBuilder = $this->queryBuilder
             ->withStart(new Natural(0))
             ->withLimit(new Natural(30));
+
+        $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
+
+        $this->expectQueryBuilderWillReturnResultSet($expectedQueryBuilder, $expectedResultSet);
+
+        $this->controller->search($request);
+    }
+
+    /**
+     * @test
+     */
+    public function it_filters_out_deleted_organizers_by_default()
+    {
+        $request = new Request([]);
+
+        $expectedQueryBuilder = $this->queryBuilder
+            ->withStart(new Natural(0))
+            ->withLimit(new Natural(30))
+            ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
 

--- a/tests/OrganizerSearchControllerTest.php
+++ b/tests/OrganizerSearchControllerTest.php
@@ -141,7 +141,8 @@ class OrganizerSearchControllerTest extends \PHPUnit_Framework_TestCase
 
         $expectedQueryBuilder = $this->queryBuilder
             ->withStart(new Natural(0))
-            ->withLimit(new Natural(30));
+            ->withLimit(new Natural(30))
+            ->withWorkflowStatusFilter(new WorkflowStatus('ACTIVE'));
 
         $expectedResultSet = new PagedResultSet(new Natural(30), new Natural(0), []);
 


### PR DESCRIPTION
### Added

- Added `workflowStatus` url parameter on organizer requests
- Added default organizer filter to filter out deleted organizers
- Added `disableDefaultFilters` url parameter on organizer requests

### Changed

- [internal] Moved parsing of workflowStatus url parameter for offers to a separate `OfferRequestParser` class